### PR TITLE
Set ansible_user to root

### DIFF
--- a/docs/automated_deploy.md
+++ b/docs/automated_deploy.md
@@ -35,6 +35,10 @@ and the public key "id_rsa.pub" to
 
 2] This tool has to be run from the OLVM Server itself.
 
+3] This tool has to be run either using the root user
+OR the non-root user should have passwordless ssh access
+to the root user.
+
 ## Script Usage
 
 <!-- markdownlint-disable MD040 -->

--- a/docs/examples/hosts.ini.example
+++ b/docs/examples/hosts.ini.example
@@ -14,7 +14,7 @@
 # Define group with one host, which is the OLVM host (manager)
 #
 [olvm]
-<OLVM FQDN>
+<OLVM FQDN> ansible_user=root
 
 #
 # Define the variables for the OLVM host, admin password will be
@@ -36,20 +36,20 @@ olvm_cafile=</PATH/TO/ca.pem>
 # The first column indicates the name of the VM that will be created in OLVM. Below values are only for representation and can be changed.
 #
 [virtualmachines]
-vm01 ansible_host=<VM1_FQDN> ansible_ssh_host=<VM1_IPADDRESS>
-vm02 ansible_host=<VM2_FQDN> ansible_ssh_host=<VM2_IPADDRESS>
-vm03 ansible_host=<VM3_FQDN> ansible_ssh_host=<VM3_IPADDRESS>
-# vm04 ansible_host=<VM4_FQDN> ansible_ssh_host=<VM4_IPADDRESS>
-# vm05 ansible_host=<VM5_FQDN> ansible_ssh_host=<VM5_IPADDRESS>
+vm01 ansible_host=<VM1_FQDN> ansible_ssh_host=<VM1_IPADDRESS> ansible_user=root
+vm02 ansible_host=<VM2_FQDN> ansible_ssh_host=<VM2_IPADDRESS> ansible_user=root
+vm03 ansible_host=<VM3_FQDN> ansible_ssh_host=<VM3_IPADDRESS> ansible_user=root
+# vm04 ansible_host=<VM4_FQDN> ansible_ssh_host=<VM4_IPADDRESS> ansible_user=root
+# vm05 ansible_host=<VM5_FQDN> ansible_ssh_host=<VM5_IPADDRESS> ansible_user=root
 
 #
 # Define the VMs to create as follows when using DHCP. Comment or delete below section if using Static IP.
 # The first column indicates the name of the VM that will be created in OLVM. Below values are only for representation and can be changed.
 #
 # [virtualmachines]
-# vm01 ansible_host=<VM1_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx
-# vm02 ansible_host=<VM2_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx
-# vm03 ansible_host=<VM3_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx
+# vm01 ansible_host=<VM1_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx ansible_user=root
+# vm02 ansible_host=<VM2_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx ansible_user=root
+# vm03 ansible_host=<VM3_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx ansible_user=root
 
 #
 

--- a/docs/manual_deploy.md
+++ b/docs/manual_deploy.md
@@ -60,6 +60,12 @@ Edit /etc/ansible/ansible.cfg and set "host_key_checking" to "False"
 
 `host_key_checking = False`
 
+## Run as root user
+
+This tool has to be run either using the root user
+OR the non-root user should have passwordless ssh access
+to the root user.
+
 ## Running the Ansible Playbooks
 
 ## Kubernetes Deployment

--- a/playbooks/hosts.ini
+++ b/playbooks/hosts.ini
@@ -14,7 +14,7 @@
 # Define group with one host, which is the OLVM host (manager)
 #
 [olvm]
-<OLVM FQDN>
+<OLVM FQDN> ansible_user=root
 
 #
 # Define the variables for the OLVM host, admin password will be
@@ -36,20 +36,20 @@ olvm_cafile=</PATH/TO/ca.pem>
 # The first column indicates the name of the VM that will be created in OLVM. Below values are only for representation and can be changed.
 #
 [virtualmachines]
-vm01 ansible_host=<VM1_FQDN> ansible_ssh_host=<VM1_IPADDRESS>
-vm02 ansible_host=<VM2_FQDN> ansible_ssh_host=<VM2_IPADDRESS>
-vm03 ansible_host=<VM3_FQDN> ansible_ssh_host=<VM3_IPADDRESS>
-# vm04 ansible_host=<VM4_FQDN> ansible_ssh_host=<VM4_IPADDRESS>
-# vm05 ansible_host=<VM5_FQDN> ansible_ssh_host=<VM5_IPADDRESS>
+vm01 ansible_host=<VM1_FQDN> ansible_ssh_host=<VM1_IPADDRESS> ansible_user=root
+vm02 ansible_host=<VM2_FQDN> ansible_ssh_host=<VM2_IPADDRESS> ansible_user=root
+vm03 ansible_host=<VM3_FQDN> ansible_ssh_host=<VM3_IPADDRESS> ansible_user=root
+# vm04 ansible_host=<VM4_FQDN> ansible_ssh_host=<VM4_IPADDRESS> ansible_user=root
+# vm05 ansible_host=<VM5_FQDN> ansible_ssh_host=<VM5_IPADDRESS> ansible_user=root
 
 #
 # Define the VMs to create as follows when using DHCP. Comment or delete below section if using Static IP.
 # The first column indicates the name of the VM that will be created in OLVM. Below values are only for representation and can be changed.
 #
 # [virtualmachines]
-# vm01 ansible_host=<VM1_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx
-# vm02 ansible_host=<VM2_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx
-# vm03 ansible_host=<VM3_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx
+# vm01 ansible_host=<VM1_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx ansible_user=root
+# vm02 ansible_host=<VM2_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx ansible_user=root
+# vm03 ansible_host=<VM3_FQDN> ansible_vm_mac=xx:xx:xx:xx:xx:xx ansible_user=root
 
 #
 

--- a/scripts/cluster_setup.py
+++ b/scripts/cluster_setup.py
@@ -53,7 +53,7 @@ def setocneconfig(nr_control_nodes,nr_worker_nodes,vm_ram,use_dhcp):
             vm_name = raw_input("Enter the Name of Control Plane Node:")
             vm_fqdn = raw_input("Enter the FQDN of Control Plane Node:")
             vm_ipaddr = raw_input("Enter the IP Address of Control Plane Node:")
-            os.system('echo "%s ansible_host=%s ansible_ssh_host=%s" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_ipaddr, currentdir))
+            os.system('echo "%s ansible_host=%s ansible_ssh_host=%s ansible_user=root" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_ipaddr, currentdir))
             controlplanenodes.append(vm_name)
             controlplanefqdn.append(vm_fqdn)
         for j in range(int(nr_worker_nodes)):
@@ -62,7 +62,7 @@ def setocneconfig(nr_control_nodes,nr_worker_nodes,vm_ram,use_dhcp):
             vm_name = raw_input("Enter the Name of Worker Node:")
             vm_fqdn = raw_input("Enter the FQDN of Worker Node:")
             vm_ipaddr = raw_input("Enter the IP Address of Worker Node:")
-            os.system('echo "%s ansible_host=%s ansible_ssh_host=%s" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_ipaddr, currentdir))
+            os.system('echo "%s ansible_host=%s ansible_ssh_host=%s ansible_user=root" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_ipaddr, currentdir))
             workernodes.append(vm_name)
             workernodefqdn.append(vm_fqdn)
 
@@ -74,7 +74,7 @@ def setocneconfig(nr_control_nodes,nr_worker_nodes,vm_ram,use_dhcp):
             vm_name = raw_input("Enter the Name of Control Plane Node:")
             vm_fqdn = raw_input("Enter the FQDN of Control Plane Node:")
             vm_mac = raw_input("Enter the MAC Address of Control Plane Node:")
-            os.system('echo "%s ansible_host=%s ansible_vm_mac=%s" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_mac, currentdir))
+            os.system('echo "%s ansible_host=%s ansible_vm_mac=%s ansible_user=root" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_mac, currentdir))
             controlplanenodes.append(vm_name)
             controlplanefqdn.append(vm_fqdn)
         for j in range(int(nr_worker_nodes)):
@@ -83,7 +83,7 @@ def setocneconfig(nr_control_nodes,nr_worker_nodes,vm_ram,use_dhcp):
             vm_name = raw_input("Enter the Name of Worker Node:")
             vm_fqdn = raw_input("Enter the FQDN of Worker Node:")
             vm_mac = raw_input("Enter the MAC Address of Worker Node:")
-            os.system('echo "%s ansible_host=%s ansible_vm_mac=%s" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_mac, currentdir))
+            os.system('echo "%s ansible_host=%s ansible_vm_mac=%s ansible_user=root" >> %s/hosts.ini' % (vm_name, vm_fqdn, vm_mac, currentdir))
             workernodes.append(vm_name)
             workernodefqdn.append(vm_fqdn)
 

--- a/scripts/environment_setup.py
+++ b/scripts/environment_setup.py
@@ -49,7 +49,7 @@ def proxyconf(currentdir):
 ## Function to add OLVM FQDN, CA Certificate file location and user
 
 def hosts(currentdir,olvm_fqdn,olvm_cafile,olvm_user):
-    os.system('echo "[olvm]" > "%s"/hosts.ini; echo "%s" >> "%s"/hosts.ini; echo " " >> "%s"/hosts.ini' % (currentdir, olvm_fqdn, currentdir, currentdir))
+    os.system('echo "[olvm]" > "%s"/hosts.ini; echo "%s ansible_user=root" >> "%s"/hosts.ini; echo " " >> "%s"/hosts.ini' % (currentdir, olvm_fqdn, currentdir, currentdir))
     os.system('echo "[olvm:vars]" >> "%s"/hosts.ini; echo "olvm_fqdn=%s" >> "%s"/hosts.ini; echo "olvm_user=%s" >> "%s"/hosts.ini; echo "olvm_cafile=%s" >> "%s"/hosts.ini;  echo " " >> "%s"/hosts.ini' % (currentdir, olvm_fqdn, currentdir, olvm_user, currentdir, olvm_cafile, currentdir, currentdir))
 
 ## Function to get password to setup for the VMs and store in to password.yml


### PR DESCRIPTION
Set ansible_user as root to prevent failures when running the tool as a non-root user.
The user may or may not have sudo access.
This change requires the non-root user to have passwordless ssh access to root user.

Signed-off-by: 44045524+shishirhegde16@users.noreply.github.com